### PR TITLE
Fix regexp of google calendar description.

### DIFF
--- a/app/scrapers/nbis_events_scraper.rb
+++ b/app/scrapers/nbis_events_scraper.rb
@@ -36,7 +36,7 @@ class NbisEventsScraper < Tess::Scrapers::Scraper
         end
         event.keywords = tags
         event.description = desc
-        if(u = desc.match(/^#url:\s*(.*)/))
+        if(u = desc.match(/\s#url:\s*(\S*)/))
           event.url = u[1]
         else
           event.url = item['htmlLink']


### PR DESCRIPTION
Change regexp as the description string from google calendar events is
without line breaks.